### PR TITLE
Adding support for providing GitHub token in a file

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"runtime"
@@ -57,6 +58,13 @@ func main() {
 	}
 	arg.MustParse(&c)
 
+	if tokfile := os.Getenv("GITHUB_TOKEN_FILE"); c.GitHubToken == "" && tokfile != "" {
+		t, err := ioutil.ReadFile(tokfile)
+		if err != nil {
+			panic(err)
+		}
+		c.GitHubToken = strings.TrimSpace(string(t))
+	}
 	if c.GitHubToken == "" {
 		panic("GITHUB_TOKEN is required")
 	}


### PR DESCRIPTION
In certain deployments it's more secure to be able to read a file containing the GitHub token, rather than providing it in an environment variable. Here's a PR that adds support for that.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>